### PR TITLE
fix(toolchain): use resolvable GraalVM version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-java = "oracle-graalvm-21.0.11+10.0.LTS"
+java = "oracle-graalvm-21.0.11"


### PR DESCRIPTION
Restore CI setup by replacing the removed legacy mise Java identifier with the canonical identifier for the same Oracle GraalVM 21.0.11 release.

Verification: `mise install`; `mise exec -- java -version`; `git diff --check`.

Signed-off-by: Don Beave <donbeave@users.noreply.github.com>